### PR TITLE
Round pct_served_parks to 2 decimals

### DIFF
--- a/cdprofiles_build/sql/combine.sql
+++ b/cdprofiles_build/sql/combine.sql
@@ -173,7 +173,7 @@ JOIN_cb_contact as (
 JOIN_parks as (
     SELECT
         a.*,
-        ROUND(b.pct_served_parks, 1) as pct_served_parks
+        ROUND(b.pct_served_parks, 2) as pct_served_parks
     FROM JOIN_cb_contact a
     LEFT JOIN parks b
     ON a.borocd = b.borocd


### PR DESCRIPTION
#81 

Note: this still has the percent field as a value between 0 and 1. This might need to get updated in the future.