### PR TITLE
correcting issue of pct_served_parks not being multiplied by 100 like the the other percent variables

### DIFF
--- a/cdprofiles_build/sql/combine.sql
+++ b/cdprofiles_build/sql/combine.sql
@@ -173,7 +173,7 @@ JOIN_cb_contact as (
 JOIN_parks as (
     SELECT
         a.*,
-        ROUND(b.pct_served_parks, 2) as pct_served_parks
+        ROUND(b.pct_served_parks, 4) as pct_served_parks
     FROM JOIN_cb_contact a
     LEFT JOIN parks b
     ON a.borocd = b.borocd

--- a/cdprofiles_build/sql/in_parks_old.sql
+++ b/cdprofiles_build/sql/in_parks_old.sql
@@ -40,7 +40,7 @@ SELECT
                 WHEN area = 0 THEN 0
                 ELSE intersect_area * pop_2010 / area
             END) / SUM(pop_2010)
-    END) as pct_served_parks
+    END)*100 as pct_served_parks
 INTO PARKS_PROPORTIONAL
 FROM _PARKS
 GROUP BY borocd;


### PR DESCRIPTION
I'm uncertain if making the change to `cdprofiles_build/sql/in_parks_old.sql` was the right way to correct this.  
#102 